### PR TITLE
Setup CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,9 @@
+version: 2.1
+
+orbs:
+  maven: circleci/maven@0.0.12
+
+workflows:
+  maven_test:
+    jobs:
+      - maven/test # checkout, build, test, and upload test results

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,58 @@
-version: 2.1
+version: 2 # use CircleCI 2.0
+jobs:
+  build:
 
-orbs:
-  maven: circleci/maven@0.0.12
+    working_directory: ~/liboqs-java # directory where steps will run
 
-workflows:
-  maven_test:
-    jobs:
-      - maven/test # checkout, build, test, and upload test results
+    docker: # run the steps with Docker
+      - image: circleci/openjdk:9-jdk
+
+    steps: # a collection of executable commands
+
+      - checkout # check out source code to working directory
+
+      - run:
+          name: Install liboqs dependencies
+          command: sudo apt-get update && sudo apt-get install cmake gcc ninja-build libssl-dev python3-pytest python3-pytest-xdist unzip xsltproc doxygen graphviz -y
+
+      - run:
+          name: Clone liboqs-master
+          command: .circleci/git_no_checkin_in_last_day.sh || (cd ~/ && git clone --branch master --single-branch https://github.com/open-quantum-safe/liboqs)
+
+      - run:
+          name: Build liboqs-master
+          command: .circleci/git_no_checkin_in_last_day.sh || (cd ~/liboqs && mkdir build && cd build && cmake -GNinja -DBUILD_SHARED_LIBS=ON .. && ninja && sudo ninja install)
+
+      - run:
+          name: Print Java home contents
+          command: java -version && echo $JAVA_HOME && ls $JAVA_HOME
+
+      - restore_cache: # restore the saved cache after the first run or if `pom.xml` has changed
+          key: 'liboqs-java-{{ checksum "pom.xml" }}-{{ arch }}'
+
+      - run:
+          name: Resolve all maven project dependencies
+          command: mvn dependency:go-offline
+
+      - save_cache: # saves project dependencies
+          paths:
+            - ~/.m2
+          key: 'liboqs-java-{{ checksum "pom.xml" }}-{{ arch }}'
+
+      - run:
+          name: Build the package and run the tests
+          command: export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib" && mvn package
+
+      - run:
+          name: Compile KEMs, Signatures and Rand examples
+          command: javac -cp target/liboqs-java.jar examples/KEMExample.java && javac -cp target/liboqs-java.jar examples/SigExample.java && javac -cp target/liboqs-java.jar examples/RandExample.java
+
+      - run:
+          name: Run KEMs, Signatures and Rand examples
+          command: export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib" && java -Djava.library.path=target/ -cp target/liboqs-java.jar:examples/ KEMExample && java -Djava.library.path=target/ -cp target/liboqs-java.jar:examples/ SigExample && java -Djava.library.path=target/ -cp target/liboqs-java.jar:examples/ RandExample
+
+      - store_test_results: # uploads the test metadata from the `target/surefire-reports` directory so that it can show up in the CircleCI dashboard.
+          path: target/surefire-reports
+
+      - store_artifacts: # store the uberjar as an artifact
+          path: target/liboqs-java.jar

--- a/.circleci/git_no_checkin_in_last_day.sh
+++ b/.circleci/git_no_checkin_in_last_day.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Detects whether there has been a Git commit in the last day on this
+# branch. Returns 1 if there has been a commit, 0 if there has not.
+
+r=`git log --name-only --since="1 day ago" -n 2`
+if [ "x$r" == "x" ]; then
+	echo "No commit in the last day. No build/test required. Exiting."
+	exit 0
+else
+	exit 1
+fi

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# liboqs-java: Java wrapper for liboqs [![License MIT][badge-license]](LICENSE)
+# liboqs-java: Java wrapper for liboqs [![Build status - CircleCI Linux][badge-circleci]](https://circleci.com/gh/open-quantum-safe/liboqs-java) [![License MIT][badge-license]](LICENSE)
 
 **liboqs-java** offers a Java wrapper providing quantum-resistant cryptographic algorithms via [liboqs](https://github.com/open-quantum-safe/liboqs/).
 
@@ -305,4 +305,5 @@ Contributors to the liboqs-java wrapper include:
 [KEM-overview]: ./images/KEM.png
 [DS-overview]: ./images/digital-signature.png
 
-[badge-license]: https://img.shields.io/badge/license-MIT-green.svg?style=flat-square
+[badge-license]: https://img.shields.io/badge/license-MIT-brightgreen.svg?style=svg
+[badge-circleci]: https://img.shields.io/circleci/build/github/open-quantum-safe/liboqs-java?logo=circleci

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0-M4</version>
+                <version>2.22.0</version>
                 <configuration>
                     <argLine>-Xss10M -Djava.library.path=${project.build.directory}</argLine>
                 </configuration>


### PR DESCRIPTION
Address issue #4.

Install liboqs dependencies and build it, build liboqs-java and run both the tests and the examples. [Here](https://app.circleci.com/pipelines/github/open-quantum-safe/liboqs-java) is the liboqs-java CircleCI status.