### PR TITLE
Create a standalone jar

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,14 +16,14 @@ version: 2
         name: Build liboqs-master
         command: .circleci/git_no_checkin_in_last_day.sh || (cd ~/liboqs && mkdir build && cd build && cmake -GNinja -DBUILD_SHARED_LIBS=ON .. && ninja && ${SUDO} ninja install)
     - restore_cache:
-        key: 'liboqs-java-{{ checksum "pom.xml" }}-{{ arch }}'
+        key: 'liboqs-java-{{ checksum "pom.xml" }}-{{ .Branch }}-{{ arch }}'
     - run:
         name: Resolve all maven project dependencies
         command: .circleci/git_no_checkin_in_last_day.sh || (mvn dependency:go-offline)
     - save_cache:
         paths:
           - ~/.m2
-        key: 'liboqs-java-{{ checksum "pom.xml" }}-{{ arch }}'
+        key: 'liboqs-java-{{ checksum "pom.xml" }}-{{ .Branch }}-{{ arch }}'
     - run:
         name: Build the package and run the tests
         command: .circleci/git_no_checkin_in_last_day.sh || (export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/local/lib" && mvn package)

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ We acknowledge that some parties may want to begin deploying post-quantum crypto
 
 
 ## Building
-Builds have been tested on Linux (Ubuntu 18.04 LTS and 19.10) and macOS Mojave with OpenJDK 8, 9, 11.
+Builds have been tested on Linux (Ubuntu 18.04 LTS, 19.10, and 20.04) and macOS Mojave with OpenJDK 8, 9, 11.
 
 ### Pre-requisites
 To build the Java OQS wrapper you need a Java Development Kit (JDK), such as [OpenJDK](https://openjdk.java.net/) >= 8 and [Apache Maven](https://maven.apache.org/).
@@ -99,7 +99,7 @@ The default profile for building is `linux`, so when building on Linux the `-P <
 
 You may also omit the `-Dliboqs.include.dir` and `-Dliboqs.lib.dir` options in case you installed liboqs in `/usr/local` (true if you ran `sudo ninja install` after building liboqs).
 
-Both the above commands will create a `target` directory with all the build files, as well as with the `liboqs-java.jar` wrapper inside the `target` directory.
+Both the above commands will create a `target` directory with the build files, as well as a `src/main/resources` directory that will contain the `liboqs-jni.so` native library. Finally, a `liboqs-java.jar` will be created inside the `target` directory that will contain all the class files as well as the `liboqs-jni.so` native library.
 
 
 ### Building and running the examples
@@ -127,7 +127,7 @@ The examples include:
 To compile and run the KEM example, type:
 ```
 $ javac -cp target/liboqs-java.jar examples/KEMExample.java
-$ java -Djava.library.path=target/ -cp target/liboqs-java.jar:examples/ KEMExample
+$ java -cp target/liboqs-java.jar:examples/ KEMExample
 ```
 
 ```
@@ -185,7 +185,7 @@ Shared secrets coincide? true
 
 ```
 $ javac -cp target/liboqs-java.jar examples/SigExample.java
-$ java -Djava.library.path=target/ -cp target/liboqs-java.jar:examples/ SigExample
+$ java -cp target/liboqs-java.jar:examples/ SigExample
 ```
 
 ```
@@ -249,7 +249,7 @@ Valid signature? true
 
 ```
 $ javac -cp target/liboqs-java.jar examples/RandExample.java
-$ java -Djava.library.path=target/ -cp target/liboqs-java.jar:examples/ RandExample
+$ java -cp target/liboqs-java.jar:examples/ RandExample
 ```
 
 ```
@@ -280,6 +280,16 @@ System (default):   37 55 6F 4F 03 53 BB 71 E8 70 C2 3D DF 85 69 57 30 CE FA 11 
         Try providing the `-Dliboqs.include.dir` and `-Dliboqs.lib.dir` command line options to maven as mentioned in the [build instructions](https://github.com/open-quantum-safe/liboqs-java#building-the-java-oqs-wrapper).
 
 * __Runtime errors__
+    * If Java cannot find native library:
+        ```
+          Exception in thread "main" java.lang.ExceptionInInitializerError
+            at ...
+          Caused by: java.lang.NullPointerException
+            at org.openquantumsafe.Common.loadNativeLibrary(Common.java:51)
+            at ...
+        ```
+        try passing to the java library path the directory that contains the native library (e.g., `java -Djava.library.path=src/main/resources/ -cp target/liboqs-java.jar:examples/ KEMExample`).
+    
     * If Java cannot find `liboqs`:
         ```
         Exception in thread "main" java.lang.UnsatisfiedLinkError:

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.openquantumsafe</groupId>
     <artifactId>liboqs-java</artifactId>
@@ -84,7 +84,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.0</version>
                 <configuration>
-                    <!--                    <argLine>-Xss10M -Djava.library.path=${project.build.directory}</argLine>-->
                     <argLine>-Xss10M -Djava.library.path=${basedir}/src/main/resources/</argLine>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.openquantumsafe</groupId>
     <artifactId>liboqs-java</artifactId>
@@ -84,7 +84,8 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.0</version>
                 <configuration>
-                    <argLine>-Xss10M -Djava.library.path=${project.build.directory}</argLine>
+                    <!--                    <argLine>-Xss10M -Djava.library.path=${project.build.directory}</argLine>-->
+                    <argLine>-Xss10M -Djava.library.path=${basedir}/src/main/resources/</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -94,6 +95,23 @@
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.0.0</version>
+                <executions>
+                    <execution>
+                        <phase>initialize</phase>
+                        <configuration>
+                            <target>
+                                <mkdir dir="${basedir}/src/main/resources/"/>
+                            </target>
+                        </configuration>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -131,7 +149,7 @@
                     </linkerStartOptions>
                     <linkerFinalName/>
                     <linkerEndOptions>
-                        <linkerEndOption>-o ${project.build.directory}/${lib_name}</linkerEndOption>
+                        <linkerEndOption>-o ${basedir}/src/main/resources/${lib_name}</linkerEndOption>
                         <linkerEndOption>-loqs</linkerEndOption>
                     </linkerEndOptions>
                 </configuration>
@@ -144,6 +162,27 @@
                             <goal>compile</goal>
                             <goal>link</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>copy-resources</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/src/main/resources/</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/java/org/openquantumsafe/Common.java
+++ b/src/main/java/org/openquantumsafe/Common.java
@@ -1,11 +1,60 @@
 package org.openquantumsafe;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.file.Files;
 import java.util.Arrays;
 
 public class Common {
 
+    private static final String OS = System.getProperty("os.name").toLowerCase();
+
     public static void wipe(byte[] array) {
         Arrays.fill(array, (byte) 0);
+    }
+
+    public static boolean isWindows() {
+        return OS.contains("win");
+    }
+
+    public static boolean isMac() {
+        return OS.contains("mac");
+    }
+
+    public static boolean isLinux() {
+        return OS.contains("nux");
+    }
+
+    public static void loadNativeLibrary() {
+        // If the library is in the java library path, load it directly. (e.g., -Djava.library.path=src/main/resources)
+        try {
+            System.loadLibrary("oqs-jni");
+        // Otherwise load the library from the liboqs-java.jar
+        } catch (UnsatisfiedLinkError e) {
+            String libName = "llliboqs-jni.so";
+            if (Common.isLinux()) {
+                libName = "liboqs-jni.so";
+            } else if (Common.isMac()) {
+                libName = "liboqs-jni.jnilib";
+            } else if (Common.isWindows()) {
+                libName = "oqs-jni.dll";
+            }
+            URL url = KEMs.class.getResource("/" + libName);
+            File tmpDir;
+            try {
+                tmpDir = Files.createTempDirectory("oqs-native-lib").toFile();
+                tmpDir.deleteOnExit();
+                File nativeLibTmpFile = new File(tmpDir, libName);
+                nativeLibTmpFile.deleteOnExit();
+                InputStream in = url.openStream();
+                Files.copy(in, nativeLibTmpFile.toPath());
+                System.load(nativeLibTmpFile.getAbsolutePath());
+            } catch (IOException ioException) {
+                ioException.printStackTrace();
+            }
+        }
     }
 
     public static <E, T extends Iterable<E>> void print_list(T list) {

--- a/src/main/java/org/openquantumsafe/KEMs.java
+++ b/src/main/java/org/openquantumsafe/KEMs.java
@@ -9,9 +9,9 @@ import java.util.ArrayList;
 public class KEMs {
     
     static {
-        System.loadLibrary("oqs-jni");
+        Common.loadNativeLibrary();
     }
-    
+
     /**
      * The single KEMs class instance.
      */

--- a/src/main/java/org/openquantumsafe/Rand.java
+++ b/src/main/java/org/openquantumsafe/Rand.java
@@ -6,7 +6,7 @@ package org.openquantumsafe;
 public class Rand {
 
     static {
-        System.loadLibrary("oqs-jni");
+        Common.loadNativeLibrary();
     }
 
     private Rand() {}

--- a/src/main/java/org/openquantumsafe/Sigs.java
+++ b/src/main/java/org/openquantumsafe/Sigs.java
@@ -7,9 +7,9 @@ import java.util.ArrayList;
  * Singleton class, contains details about supported/enabled signature mechanisms
  */
 public class Sigs {
-    
+
     static {
-        System.loadLibrary("oqs-jni");
+        Common.loadNativeLibrary();
     }
     
     /**


### PR DESCRIPTION
Bundle the native library in the liboqs-java.jar wrapper. If the native library is in java.library.path, load it directly, otherwise extract it from the jar.

Previously we had to provide the location of the native `liboqs-jni.so` to the `java.library.path` (e.g., `java -Djava.library.path=target -cp target/liboqs-java.jar:examples/ KEMExample`). Now the `liboqs-jni.so` is also packaged inside the generated jar and the java code loads it dynamically if it is not found in the java.library.path.

Example usage:
```
javac -cp target/liboqs-java.jar examples/KEMExample.java
java -cp target/liboqs-java.jar:examples/ KEMExample
```

@christianpaquin We can now also add the generated liboqs-java.jar in the release.
