### PR TITLE
Fix missing parameter needed at least on android

### DIFF
--- a/src/main/c/KeyEncapsulation.c
+++ b/src/main/c/KeyEncapsulation.c
@@ -46,7 +46,7 @@ JNIEXPORT jobject JNICALL Java_org_openquantumsafe_KeyEncapsulation_get_1KEM_1de
     if (NULL == constructor_meth_id_) { fprintf(stderr, "\nCould not initialize class\n"); return NULL; }
 
     // Call back constructor to allocate a new instance, with an int argument
-    jobject _nativeKED = (*env)->NewObject(env, cls, constructor_meth_id_);
+    jobject _nativeKED = (*env)->NewObject(env, cls, constructor_meth_id_, obj);
 
     OQS_KEM *kem = (OQS_KEM *) getHandle(env, obj, "native_kem_handle_");
 

--- a/src/main/c/Signature.c
+++ b/src/main/c/Signature.c
@@ -46,7 +46,7 @@ JNIEXPORT jobject JNICALL Java_org_openquantumsafe_Signature_get_1sig_1details
     if (NULL == constructor_meth_id_) { fprintf(stderr, "\nCould not initialize class\n"); return NULL; }
 
     // Call back constructor to allocate a new instance, with an int argument
-    jobject _nativeKED = (*env)->NewObject(env, cls, constructor_meth_id_);
+    jobject _nativeKED = (*env)->NewObject(env, cls, constructor_meth_id_, obj);
 
     OQS_SIG *sig = (OQS_SIG *) getHandle(env, obj, "native_sig_handle_");
 
@@ -133,7 +133,7 @@ JNIEXPORT jint JNICALL Java_org_openquantumsafe_Signature_sign
     jfieldID value_fid = (*env)->GetFieldID(env,
                                     (*env)->GetObjectClass(env, sig_len_obj),
                                     "value", "Ljava/lang/Object;");
-    jclass cls = (*env)->FindClass(env, "Ljava/lang/Long;");
+    jclass cls = (*env)->FindClass(env, "java/lang/Long");
     jobject jlong_obj = (*env)->NewObject(env, cls,
                                 (*env)->GetMethodID(env, cls, "<init>", "(J)V"),
                                 (jlong) len_sig);


### PR DESCRIPTION
As mentioned in #11 no matter of how the jni is integrated for android it fails as `local referenced is deleted` or something.  
After debugging it on my android device i found out that for innerclasses the superclass must be passed as well.   
https://stackoverflow.com/questions/25363027/jni-getmethodid-not-working-for-constructor-of-inner-class
I dont have a clue why it is working on common jvms for linux or windows but it crashes on android.  
I tested the fix locally on my android device and with ci in github for x86_64 and arm64: 
 https://github.com/Hatzen/LibOQSTestApp/runs/2249616782   
  
I didnt test it yet for previous working common jvms. But i hope circle ci can do this at this point?  