### PR TITLE
Optimize pom.xml & Some fixes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,16 +20,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <version>3.8.1</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-jar-plugin</artifactId>
-            <version>3.2.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <version>5.6.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -43,7 +43,8 @@
                 </property>
             </activation>
             <properties>
-                <lib_name>liboqs-jni.jnilib</lib_name>
+                <lib_name>liboqs-jni</lib_name>
+                <lib_name_ext>jnilib</lib_name_ext>
                 <liboqs.include.dir>/usr/local/include</liboqs.include.dir>
                 <liboqs.lib.dir>/usr/local/lib</liboqs.lib.dir>
                 <java.os.include>-I${JAVA_HOME}/include -I${JAVA_HOME}/include/darwin</java.os.include>
@@ -59,7 +60,8 @@
                 </property>
             </activation>
             <properties>
-                <lib_name>liboqs-jni.so</lib_name>
+                <lib_name>liboqs-jni</lib_name>
+                <lib_name_ext>so</lib_name_ext>
                 <liboqs.include.dir>/usr/local/include</liboqs.include.dir>
                 <liboqs.lib.dir>/usr/local/lib</liboqs.lib.dir>
                 <java.os.include>-I${JAVA_HOME}/include -I${JAVA_HOME}/include/linux</java.os.include>
@@ -74,7 +76,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.22.0</version>
                 <configuration>
-                    <argLine>-Xss10M -Djava.library.path=${basedir}/src/main/resources/</argLine>
+                    <argLine>-Xss10M -Djava.library.path=${project.build.outputDirectory}</argLine>
                 </configuration>
             </plugin>
             <plugin>
@@ -84,23 +86,6 @@
                     <source>1.8</source>
                     <target>1.8</target>
                 </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-antrun-plugin</artifactId>
-                <version>3.0.0</version>
-                <executions>
-                    <execution>
-                        <phase>initialize</phase>
-                        <configuration>
-                            <target>
-                                <mkdir dir="${basedir}/src/main/resources/"/>
-                            </target>
-                        </configuration>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -130,15 +115,15 @@
                         <compilerStartOption>-O3</compilerStartOption>
                         <compilerStartOption>-I${liboqs.include.dir}</compilerStartOption>
                     </compilerStartOptions>
-                    <linkerOutputDirectory>target</linkerOutputDirectory>
+                    <linkerOutputDirectory>${project.build.outputDirectory}</linkerOutputDirectory>
                     <linkerExecutable>gcc</linkerExecutable>
                     <linkerStartOptions>
                         <linkerStartOption>-shared</linkerStartOption>
                         <linkerStartOption>-L${liboqs.lib.dir}</linkerStartOption>
                     </linkerStartOptions>
-                    <linkerFinalName/>
+                    <linkerFinalName>${lib_name}</linkerFinalName>
+                    <linkerFinalNameExt>${lib_name_ext}</linkerFinalNameExt>
                     <linkerEndOptions>
-                        <linkerEndOption>-o ${basedir}/src/main/resources/${lib_name}</linkerEndOption>
                         <linkerEndOption>-loqs</linkerEndOption>
                     </linkerEndOptions>
                 </configuration>
@@ -151,27 +136,6 @@
                             <goal>compile</goal>
                             <goal>link</goal>
                         </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-resources-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>copy-resources</id>
-                        <phase>process-classes</phase>
-                        <goals>
-                            <goal>copy-resources</goal>
-                        </goals>
-                        <configuration>
-                            <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-                            <resources>
-                                <resource>
-                                    <directory>${basedir}/src/main/resources/</directory>
-                                </resource>
-                            </resources>
-                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/main/c/KeyEncapsulation.c
+++ b/src/main/c/KeyEncapsulation.c
@@ -105,8 +105,8 @@ JNIEXPORT jint JNICALL Java_org_openquantumsafe_KeyEncapsulation_generate_1keypa
     // Invoke liboqs KEM keypair generation function
     OQS_STATUS rv_ = OQS_KEM_keypair(kem, (uint8_t*) public_key_native, (uint8_t*) secret_key_native);
 
-    (*env)->ReleaseByteArrayElements(env, jpublic_key, public_key_native, JNI_COMMIT);
-    (*env)->ReleaseByteArrayElements(env, jsecret_key, secret_key_native, JNI_COMMIT);
+    (*env)->ReleaseByteArrayElements(env, jpublic_key, public_key_native, 0);
+    (*env)->ReleaseByteArrayElements(env, jsecret_key, secret_key_native, 0);
     return (rv_ == OQS_SUCCESS) ? 0 : -1;
 }
 
@@ -129,8 +129,8 @@ JNIEXPORT jint JNICALL Java_org_openquantumsafe_KeyEncapsulation_encap_1secret
 
     // Release C public_key
     (*env)->ReleaseByteArrayElements(env, jpublic_key, public_key, JNI_ABORT);
-    (*env)->ReleaseByteArrayElements(env, jciphertext, ciphertext, JNI_COMMIT);
-    (*env)->ReleaseByteArrayElements(env, jshared_secret, shared_secret, JNI_COMMIT);
+    (*env)->ReleaseByteArrayElements(env, jciphertext, ciphertext, 0);
+    (*env)->ReleaseByteArrayElements(env, jshared_secret, shared_secret, 0);
     return (rv_ == OQS_SUCCESS) ? 0 : -1;
 }
 
@@ -150,7 +150,7 @@ JNIEXPORT jint JNICALL Java_org_openquantumsafe_KeyEncapsulation_decap_1secret
     OQS_STATUS rv_ = OQS_KEM_decaps(kem, (uint8_t*) shared_secret_native, (uint8_t*) ciphertext_native, (uint8_t*) secret_key_native);
 
     // release memory
-    (*env)->ReleaseByteArrayElements(env, jshared_secret, shared_secret_native, JNI_COMMIT);
+    (*env)->ReleaseByteArrayElements(env, jshared_secret, shared_secret_native, 0);
     (*env)->ReleaseByteArrayElements(env, jciphertext, ciphertext_native, JNI_ABORT);
     (*env)->ReleaseByteArrayElements(env, jsecret_key, secret_key_native, JNI_ABORT);
     return (rv_ == OQS_SUCCESS) ? 0 : -1;

--- a/src/main/c/Signature.c
+++ b/src/main/c/Signature.c
@@ -101,8 +101,8 @@ JNIEXPORT jint JNICALL Java_org_openquantumsafe_Signature_generate_1keypair
     // Invoke liboqs sig keypair generation function
     OQS_STATUS rv_ = OQS_SIG_keypair(sig, (uint8_t*) public_key_native, (uint8_t*) secret_key_native);
 
-    (*env)->ReleaseByteArrayElements(env, jpublic_key, public_key_native, JNI_COMMIT);
-    (*env)->ReleaseByteArrayElements(env, jsecret_key, secret_key_native, JNI_COMMIT);
+    (*env)->ReleaseByteArrayElements(env, jpublic_key, public_key_native, 0);
+    (*env)->ReleaseByteArrayElements(env, jsecret_key, secret_key_native, 0);
     return (rv_ == OQS_SUCCESS) ? 0 : -1;
 }
 
@@ -140,7 +140,7 @@ JNIEXPORT jint JNICALL Java_org_openquantumsafe_Signature_sign
     (*env)->SetObjectField(env, sig_len_obj, value_fid, jlong_obj);
 
     // Release C memory
-    (*env)->ReleaseByteArrayElements(env, jsignature, signature_native, JNI_COMMIT);
+    (*env)->ReleaseByteArrayElements(env, jsignature, signature_native, 0);
     (*env)->ReleaseByteArrayElements(env, jmessage, message_native, JNI_ABORT);
     (*env)->ReleaseByteArrayElements(env, jsecret_key, secret_key_native, JNI_ABORT);
 

--- a/src/main/java/org/openquantumsafe/Pair.java
+++ b/src/main/java/org/openquantumsafe/Pair.java
@@ -21,8 +21,8 @@ public class Pair<L, R> {
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof Pair)) return false;
-        Pair pairo = (Pair) o;
+        if (!(o instanceof Pair<?, ?>)) return false;
+        Pair<?, ?> pairo = (Pair<?, ?>) o;
         return this.left.equals(pairo.getLeft()) && this.right.equals(pairo.getRight());
     }
 


### PR DESCRIPTION
1. Remove unnecessary dependencies
2. Fix warning: Raw use of parameterized class 'Pair'
3. Optimize the way of bundling native lib into jar
3.1. Output native library to `${project.build.outputDirectory}`, avoid using `"${basedir}/src/main/resources/"` and file copying.
3.2. Use `<linkerFinalName>` and `<linkerFinalNameExt>` to specify the output library name, otherwise invalid link instructions will be added:
   `'-o/mnt/d/OpenSource/liboqs-java/target/classes/liboqs-java.jar'`
4. Fix memory leak.
   For the `ReleaseByteArrayElements()` function, if the `mode` parameter is `JNI_COMMIT`, it will cause memory leak.
   `JNI_COMMIT`: copy back the content but do not free the elems buffer.
   `0`: copy back the content and free the elems buffer.
   But there is no macro definition of `0` in `jni.h`.
