### PR TITLE
Add support for ML-DSA context

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-liboqs-java version 0.1.0
+liboqs-java version 0.1.1
 =========================
 
 About
@@ -14,3 +14,5 @@ Release notes
 =============
 
 The initial release of liboqs-java was released on July 8, 2020. Its release page on GitHub is https://github.com/open-quantum-safe/liboqs-java/releases/tag/0.1.0.
+
+Release 0.1.1 from December 2024 added support for Signature and Verify API's which accept a Context String.

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,4 +1,4 @@
-liboqs-java version 0.1.1
+liboqs-java version 0.2.0
 =========================
 
 About
@@ -15,4 +15,4 @@ Release notes
 
 The initial release of liboqs-java was released on July 8, 2020. Its release page on GitHub is https://github.com/open-quantum-safe/liboqs-java/releases/tag/0.1.0.
 
-Release 0.1.1 from December 2024 added support for Signature and Verify API's which accept a Context String.
+Release 0.2.0 from January 2025 added support for Signature and Verify API's which accept a Context String.

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.openquantumsafe</groupId>
     <artifactId>liboqs-java</artifactId>
     <packaging>jar</packaging>
-    <version>1.0</version>
+    <version>1.1</version>
     <name>liboqs-java: Java wrapper for liboqs</name>
     <description>liboqs-java offers a Java wrapper providing quantum-resistant cryptographic algorithms via liboqs.</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <groupId>org.openquantumsafe</groupId>
     <artifactId>liboqs-java</artifactId>
     <packaging>jar</packaging>
-    <version>1.1</version>
+    <version>2.0</version>
     <name>liboqs-java: Java wrapper for liboqs</name>
     <description>liboqs-java offers a Java wrapper providing quantum-resistant cryptographic algorithms via liboqs.</description>
 

--- a/src/main/c/Signature.h
+++ b/src/main/c/Signature.h
@@ -41,32 +41,8 @@ JNIEXPORT jint JNICALL Java_org_openquantumsafe_Signature_generate_1keypair
 
 /*
  * Class:     org_openquantumsafe_Signature
- * Method:    import_secret_key
- * Signature: ([B)V
- */
-JNIEXPORT void JNICALL Java_org_openquantumsafe_Signature_import_1secret_1key
-  (JNIEnv *, jobject, jbyteArray);
-
-/*
- * Class:     org_openquantumsafe_Signature
- * Method:    export_public_key
- * Signature: ([B)V
- */
-JNIEXPORT void JNICALL Java_org_openquantumsafe_Signature_export_1public_1key
-  (JNIEnv *, jobject, jbyteArray);
-
-/*
- * Class:     org_openquantumsafe_Signature
- * Method:    export_secret_key
- * Signature: ([B)V
- */
-JNIEXPORT void JNICALL Java_org_openquantumsafe_Signature_export_1secret_1key
-  (JNIEnv *, jobject, jbyteArray);
-
-/*
- * Class:     org_openquantumsafe_Signature
  * Method:    sign
- * Signature: ([BLjava/lang/Long;[BJ[B)I
+ * Signature: ([BLorg/openquantumsafe/Signature/Mutable;[BJ[B)I
  */
 JNIEXPORT jint JNICALL Java_org_openquantumsafe_Signature_sign
   (JNIEnv *, jobject, jbyteArray, jobject, jbyteArray, jlong, jbyteArray);
@@ -78,6 +54,22 @@ JNIEXPORT jint JNICALL Java_org_openquantumsafe_Signature_sign
  */
 JNIEXPORT jboolean JNICALL Java_org_openquantumsafe_Signature_verify
   (JNIEnv *, jobject, jbyteArray, jlong, jbyteArray, jlong, jbyteArray);
+
+/*
+ * Class:     org_openquantumsafe_Signature
+ * Method:    sign_with_ctx_str
+ * Signature: ([BLorg/openquantumsafe/Signature/Mutable;[BJ[BJ[B)I
+ */
+JNIEXPORT jint JNICALL Java_org_openquantumsafe_Signature_sign_1with_1ctx_1str
+  (JNIEnv *, jobject, jbyteArray, jobject, jbyteArray, jlong, jbyteArray, jlong, jbyteArray);
+
+/*
+ * Class:     org_openquantumsafe_Signature
+ * Method:    verify_with_ctx_str
+ * Signature: ([BJ[BJ[BJ[B)Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_openquantumsafe_Signature_verify_1with_1ctx_1str
+  (JNIEnv *, jobject, jbyteArray, jlong, jbyteArray, jlong, jbyteArray, jlong, jbyteArray);
 
 #ifdef __cplusplus
 }

--- a/src/test/java/org/openquantumsafe/SigTest.java
+++ b/src/test/java/org/openquantumsafe/SigTest.java
@@ -53,6 +53,41 @@ public class SigTest {
         sb.append("\033[0;32m").append("PASSED").append("\033[0m");
         System.out.println(sb.toString());
     }
+    
+    
+    /**
+     * Test all enabled Sigs with context (if they don't support the context
+     * it should fail gracefully)
+     */
+    @ParameterizedTest(name = "Testing {arguments}")
+    @MethodSource("getEnabledSigsAsStream")
+    public void testAllSigsWithContext(String sig_name) {
+        StringBuilder sb = new StringBuilder();
+        sb.append(sig_name);
+        sb.append(String.format("%1$" + (40 - sig_name.length()) + "s", ""));
+
+        // Create signer and verifier
+        Signature signer = new Signature(sig_name);
+        Signature verifier = new Signature(sig_name);
+
+        byte[] sampleContext = new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10};
+        
+        // Generate signer key pair
+        byte[] signer_public_key = signer.generate_keypair();
+
+        // Sign the message
+        byte[] signature = signer.sign(message,sampleContext);
+
+        // Verify the signature
+        boolean is_valid = verifier.verify(message, signature, sampleContext, signer_public_key);
+
+        assertTrue(is_valid, sig_name);
+
+        // If successful print Sig name, otherwise an exception will be thrown
+        sb.append("\033[0;32m").append("PASSED").append("\033[0m");
+        System.out.println(sb.toString());
+    }
+    
 
     /**
      * Test the MechanismNotSupported Exception

--- a/src/test/java/org/openquantumsafe/SigTest.java
+++ b/src/test/java/org/openquantumsafe/SigTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
-// import java.util.Arrays;
+import java.util.Arrays;
 import java.util.stream.Stream;
 
 public class SigTest {
@@ -62,8 +62,7 @@ public class SigTest {
      * Test Sigs with context.
      */
     @ParameterizedTest(name = "Testing {arguments}")
-    @MethodSource("getEnabledSigsAsStream")
-    //@MethodSource("getMLDSASigsAsStream")
+    @MethodSource("getContextSupportedAlgsAsStream")
     public void testSigsWithContext(String sig_name) {
     	byte[] context = "01234567890".getBytes();
         StringBuilder sb = new StringBuilder();
@@ -104,12 +103,12 @@ public class SigTest {
         return enabled_sigs.parallelStream();
     }
 
-//    /**
-//     * Method to convert the list of ML-DSA Sigs to a stream for input to testAllSigs
-//     */
-//    private static Stream<String> getMLDSASigsAsStream() {
-//    	return Arrays.asList(
-//                "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"
-//            ).parallelStream();
-//    }
+    /**
+     * Method to convert the list of ML-DSA Sigs to a stream for input to testAllSigs
+     */
+    private static Stream<String> getContextSupportedAlgsAsStream() {
+    	return Arrays.asList(
+                "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"
+            ).parallelStream();
+    }
 }

--- a/src/test/java/org/openquantumsafe/SigTest.java
+++ b/src/test/java/org/openquantumsafe/SigTest.java
@@ -5,9 +5,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+
+// import static org.junit.Assert.fail;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
+// import java.util.Arrays;
 import java.util.stream.Stream;
 
 public class SigTest {
@@ -22,6 +25,7 @@ public class SigTest {
     public static void init(){
         System.out.println("Initialize list of enabled Signatures");
         enabled_sigs = Sigs.get_enabled_sigs();
+        System.out.println("Enabled signatures: [" + enabled_sigs + "]" );
     }
 
     /**
@@ -54,14 +58,14 @@ public class SigTest {
         System.out.println(sb.toString());
     }
     
-    
     /**
-     * Test all enabled Sigs with context (if they don't support the context
-     * it should fail gracefully)
+     * Test Sigs with context.
      */
     @ParameterizedTest(name = "Testing {arguments}")
     @MethodSource("getEnabledSigsAsStream")
-    public void testAllSigsWithContext(String sig_name) {
+    //@MethodSource("getMLDSASigsAsStream")
+    public void testSigsWithContext(String sig_name) {
+    	byte[] context = "01234567890".getBytes();
         StringBuilder sb = new StringBuilder();
         sb.append(sig_name);
         sb.append(String.format("%1$" + (40 - sig_name.length()) + "s", ""));
@@ -69,25 +73,21 @@ public class SigTest {
         // Create signer and verifier
         Signature signer = new Signature(sig_name);
         Signature verifier = new Signature(sig_name);
-
-        byte[] sampleContext = new byte[] {0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10};
         
-        // Generate signer key pair
+         // Generate signer key pair
         byte[] signer_public_key = signer.generate_keypair();
 
         // Sign the message
-        byte[] signature = signer.sign(message,sampleContext);
+        byte[] signature = signer.sign(message, context);
 
         // Verify the signature
-        boolean is_valid = verifier.verify(message, signature, sampleContext, signer_public_key);
-
+        boolean is_valid = verifier.verify(message, signature, context, signer_public_key);
         assertTrue(is_valid, sig_name);
-
+        
         // If successful print Sig name, otherwise an exception will be thrown
         sb.append("\033[0;32m").append("PASSED").append("\033[0m");
         System.out.println(sb.toString());
     }
-    
 
     /**
      * Test the MechanismNotSupported Exception
@@ -104,4 +104,12 @@ public class SigTest {
         return enabled_sigs.parallelStream();
     }
 
+//    /**
+//     * Method to convert the list of ML-DSA Sigs to a stream for input to testAllSigs
+//     */
+//    private static Stream<String> getMLDSASigsAsStream() {
+//    	return Arrays.asList(
+//                "ML-DSA-44", "ML-DSA-65", "ML-DSA-87"
+//            ).parallelStream();
+//    }
 }


### PR DESCRIPTION
- Added support for the ML-DSA Context 
- Updated version to 1.1
- Added Tests for testing the context in java.   
- Question:  If an algorithm that doesn't support a context calls the API with a context, is it expected to fail, or should the context just be ignored by the libOQS library.   I think it should fail because it would be operator error, and they should be alerted to the fact that they are trying to call an algorithm with a context that doesn't support a context.   